### PR TITLE
add main property to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,5 +13,6 @@
     "bower_components",
     "test",
     "tests"
-  ]
+  ],
+  "main": "lib/parallel.js"
 }


### PR DESCRIPTION
The bower.json file is missing a `main` property - this PR adds it (pointing to `lib/parallel.js`) which lets bower know which file contains the library. This is useful if you're doing `bower list --paths` as part of your build process - it allows you to do

```
Parallel = require('parallel');
```

rather than 

```
Parallel = require('bower_components/parallel/lib/parallel');
```

If you end up merging this, you would need to push new semver tags (or overwrite the existing ones) before bower consumers would get the up-to-date bower.json. Thanks!
