### PR TITLE
Reuse of workers to improve performance

### DIFF
--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -7,7 +7,6 @@
 	var Worker = isNode ? require(__dirname + '/Worker.js') : self.Worker;
 	var URL = typeof self !== 'undefined' ? (self.URL ? self.URL : self.webkitURL) : null;
 	var _supports = (isNode || self.Worker) ? true : false; // node always supports parallel
-	var _pool = [];
 
 	function extend(from, to) {
 		if (!to) to = {};
@@ -151,7 +150,6 @@
 				if (this.requiredScripts.length !== 0) {
 					if (this.options.evalPath !== null) {
 						wrk = new Worker(this.options.evalPath);
-						
 						wrk.postMessage(src);
 					} else {
 						throw new Error('Can\'t use required scripts without eval.js!');

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -203,14 +203,15 @@
 		return this;
 	};
 
-	Parallel.prototype._spawnMapWorker = function (i, cb, done, env) {
+	Parallel.prototype._spawnMapWorker = function (i, cb, done, env, wrk) {
 		var that = this;
-		var wrk = that._spawnWorker(cb, env);
+		
+		if (!wrk) wrk = that._spawnWorker(cb, env);
+		
 		if (wrk !== undefined) {
 			wrk.onmessage = function (msg) {
-				wrk.terminate();
 				that.data[i] = msg.data;
-				done();
+				done(wrk);
 			};
 			wrk.postMessage(that.data[i]);
 		} else if (that.options.synchronous) {
@@ -233,11 +234,14 @@
 		var that = this;
 		var startedOps = 0;
 		var doneOps = 0;
-		function done() {
+		function done(wrk) {
 			if (++doneOps === that.data.length) {
 				newOp.resolve(null, that.data);
+				if (wrk) wrk.terminate();
 			} else if (startedOps < that.data.length) {
-				that._spawnMapWorker(startedOps++, cb, done, env);
+				that._spawnMapWorker(startedOps++, cb, done, env,wrk);
+			} else {
+				if (wrk) wrk.terminate();
 			}
 		}
 
@@ -251,14 +255,14 @@
 		return this;
 	};
 
-	Parallel.prototype._spawnReduceWorker = function (data, cb, done, env) {
+	Parallel.prototype._spawnReduceWorker = function (data, cb, done, env,wrk) {
 		var that = this;
-		var wrk = that._spawnWorker(cb, env);
+		if (!wrk) wrk = that._spawnWorker(cb, env);
+
 		if (wrk !== undefined) {
 			wrk.onmessage = function (msg) {
-				wrk.terminate();
 				that.data[that.data.length] = msg.data;
-				done();
+				done(wrk);
 			};
 			wrk.postMessage(data);
 		} else if (that.options.synchronous) {
@@ -280,15 +284,18 @@
 
 		var runningWorkers = 0;
 		var that = this;
-		function done(data) {
+		function done(data,wrk) {
 			--runningWorkers;
 			if (that.data.length === 1 && runningWorkers === 0) {
 				that.data = that.data[0];
 				newOp.resolve(null, that.data);
+				if (wrk) wrk.terminate();
 			} else if (that.data.length > 1) {
 				++runningWorkers;
-				that._spawnReduceWorker([that.data[0], that.data[1]], cb, done, env);
+				that._spawnReduceWorker([that.data[0], that.data[1]], cb, done, env, wrk);
 				that.data.splice(0, 2);
+			} else {
+				if (wrk) wrk.terminate();
 			}
 		}
 


### PR DESCRIPTION
I modified the map(), _spawnMapWorker(), reduce(), and _spawnReduceWorker() functions to re-use workers rather than terminating and recreating them for each iteration.  This vastly improved performance for me.  When a worker is finished, I pass it to the done() function to reuse if there are more iterations required.