### PR TITLE
use navigator.hardwareConcurrency

### DIFF
--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -71,7 +71,7 @@
 
 	var defaults = {
 		evalPath: isNode ? __dirname + '/eval.js' : null,
-		maxWorkers: isNode ? require('os').cpus().length : 4,
+		maxWorkers: isNode ? require('os').cpus().length : navigator.hardwareConcurrency || 4,
 		synchronous: true,
 		env: {},
 		envNamespace: 'env'


### PR DESCRIPTION
Checks for the native ` navigator.hardwareConcurrency` for the number of maxWorkers.
This works currently only in WebKit and Blink.

PS: there is even a [polyfill](https://github.com/oftn/core-estimator) for this.