### PR TITLE
can set number of elements passed to map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *.log
 .DS_Store
 npm-debug.log
+.idea

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -203,17 +203,29 @@
 		return this;
 	};
 
-	Parallel.prototype._spawnMapWorker = function (i, cb, done, env, wrk) {
+	Parallel.prototype._spawnMapWorker = function (i, j, cb, done, env, wrk) {
 		var that = this;
 		
 		if (!wrk) wrk = that._spawnWorker(cb, env);
 		
 		if (wrk !== undefined) {
 			wrk.onmessage = function (msg) {
-				that.data[i] = msg.data;
+                wrk.terminate()
+                if(typeof(msg) == 'array') {
+                    var m = 0;
+                    for (var k = i; k < j; k++) {
+                        that.data[k] = msg.data[m++];
+                    }
+                } else {
+                    that.data[i] == msg.data;
+                }
 				done(wrk);
 			};
-			wrk.postMessage(that.data[i]);
+            if(j - i > 1) {
+                wrk.postMessage(that.data.slice(i, j));
+            } else {
+                wrk.postMessage(that.data[i]);
+            }
 		} else if (that.options.synchronous) {
 			setImmediate(function () {
 				that.data[i] = cb(that.data[i]);
@@ -224,9 +236,15 @@
 		}
 	};
 
-	Parallel.prototype.map = function (cb, env) {
-		env = extend(this.options.env, env || {});
-
+	Parallel.prototype.map = function (cb, opts) {
+         if(opts != undefined) {
+            if(opts.env != undefined) {
+                var env = extend(this.options.env, opts.env || {});
+            } else {
+                var env = extend(this.options.env, opts || {});
+            }
+        }
+        var len = (opts != undefined && opts.length != undefined ) ? opts.length : 1;
 		if (!this.data.length) {
 			return this.spawn(cb, env);
 		}
@@ -235,20 +253,27 @@
 		var startedOps = 0;
 		var doneOps = 0;
 		function done(wrk) {
-			if (++doneOps === that.data.length) {
+            doneOps+=len
+			if (doneOps == that.data.length) {
 				newOp.resolve(null, that.data);
 				if (wrk) wrk.terminate();
-			} else if (startedOps < that.data.length) {
-				that._spawnMapWorker(startedOps++, cb, done, env, wrk);
 			} else {
-				if (wrk) wrk.terminate();
-			}
+                if (startedOps < that.data.length) {
+                    if(startedOps + len < that.data.length) {
+                        that._spawnMapWorker(startedOps += len, startedOps + len, cb, done, env, wrk);
+                    } else {
+                        that._spawnMapWorker(startedOps++, startedOps + 1, cb, done, env, wrk);
+                    }
+                } else {
+                    if (wrk) wrk.terminate();
+                }
+            }
 		}
 
 		var newOp = new Operation();
 		this.operation.then(function () {
-			for (; startedOps - doneOps < that.options.maxWorkers && startedOps < that.data.length; ++startedOps) {
-				that._spawnMapWorker(startedOps, cb, done, env);
+			for (; startedOps - doneOps < that.options.maxWorkers && startedOps < that.data.length; startedOps+=len) {
+				that._spawnMapWorker(startedOps, startedOps + len, cb, done, env);
 			}
 		});
 		this.operation = newOp;
@@ -335,4 +360,5 @@
 	} else {
 		self.Parallel = Parallel;
 	}
+
 })();

--- a/package.json
+++ b/package.json
@@ -1,57 +1,58 @@
 {
-	"name": "paralleljs",
-	"version": "0.2.1",
-	"author": "Adam Savitzky <adam.savitzky@gmail.com>",
-	"contributors": [
-		"Sebastian Mayr <sebmaster16@gmail.com> (http://s3bmaster.blogspot.co.at/)"
-	],
-	"description": "parallel.js enables easy multi-thread processing in javascript",
-	"main": "lib/parallel.js",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/adambom/parallel.js.git"
-	},
-	"directories": {
-		"lib": "lib",
-		"test": "test"
-	},
-	"keywords": [
-		"parallel",
-		"spawn",
-		"map",
-		"thread",
-		"parallel.js",
-		"workers",
-		"webworkers"
-	],
-	"devDependencies": {
-		"jasmine-node": "x",
-		"q": "x"
-	},
-	"license": "BSD",
-	"scripts": {
-		"test": "jasmine-node --verbose test/specs"
-	},
-	"engines": {
-		"node": ">=0.9.10"
-	},
-	"testling" : {
-		"scripts": [
-			"lib/parallel.js",
-			"test/jasmine/jasmine.js",
-			"test/jasmine/jasmine.tap_reporter.js",
-			"test/specs/*.js",
-			"test/runner.js"
-		],
-		"browsers": [
-			"ie/9..latest",
-			"chrome/22..latest",
-			"firefox/16..latest",
-			"safari/latest",
-			"opera/11.0..latest",
-			"iphone/6",
-			"ipad/6",
-			"android-browser/latest"
-		]
-	}
+  "name": "paralleljs",
+  "version": "0.2.1",
+  "author": "Adam Savitzky <adam.savitzky@gmail.com>",
+  "contributors": [
+    "Sebastian Mayr <sebmaster16@gmail.com> (http://s3bmaster.blogspot.co.at/)"
+  ],
+  "description": "parallel.js enables easy multi-thread processing in javascript",
+  "main": "lib/parallel.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adambom/parallel.js.git"
+  },
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "keywords": [
+    "parallel",
+    "spawn",
+    "map",
+    "thread",
+    "parallel.js",
+    "workers",
+    "webworkers"
+  ],
+  "devDependencies": {
+    "jasmine-node": "x",
+    "q": "x"
+  },
+  "license": "BSD",
+  "scripts": {
+    "test": "jasmine-node --verbose test/specs"
+  },
+  "engines": {
+    "node": ">=0.9.10"
+  },
+  "testling": {
+    "scripts": [
+      "lib/parallel.js",
+      "test/jasmine/jasmine.js",
+      "test/jasmine/jasmine.tap_reporter.js",
+      "test/specs/*.js",
+      "test/runner.js"
+    ],
+    "browsers": [
+      "ie/9..latest",
+      "chrome/22..latest",
+      "firefox/16..latest",
+      "safari/latest",
+      "opera/11.0..latest",
+      "iphone/6",
+      "ipad/6",
+      "android-browser/latest"
+    ]
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
map function signature: map(cb, opts)

opts is an object: {env: the env, length: length of the argument}
If opts.length is not set, the argument passed to cb is one element of data. If it is set, the argument will be an array.
This might be useful for sorting (oddEven, merge, etc).
map stills works as map(cb, env) by passing normal env without length and env properties.